### PR TITLE
fix: missed boom error case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rutt",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "Angular inspired route config for Hapi",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/src/rutt.ts
+++ b/src/rutt.ts
@@ -161,7 +161,7 @@ export class Rutt {
     }
 
     protected handleError(err: any, reply: RuttReply) {
-        return reply.response(Boom.badImplementation(err.message || err, err.stack));
+        return Boom.badImplementation(err.message || err, err.stack);
     }
 
     protected constructController(controllerCtor: Controller<any>): any {


### PR DESCRIPTION
This was missed on my last PR to resolve Hapi errors when an error is thrown. As it's wrapping again rather than direct returning (which Hapi handles internally)